### PR TITLE
Simplify various Queue::write_submit_script implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ log = "0.4.21"
 
 [dev-dependencies]
 criterion = "0.5.0"
+insta = { version = "1.38.0" }
+tempfile = "3"
 
 [[bin]]
 name = "read_out"

--- a/src/program/cfour.rs
+++ b/src/program/cfour.rs
@@ -265,7 +265,7 @@ impl Queue<Cfour> for Slurm {
     }
 
     fn default_submit_script(&self) -> String {
-        todo!()
+        String::new()
     }
 }
 

--- a/src/program/cfour.rs
+++ b/src/program/cfour.rs
@@ -289,7 +289,7 @@ impl Submit<Cfour> for Local {}
 
 impl Queue<Cfour> for Local {
     fn default_submit_script(&self) -> String {
-        todo!()
+        "CFOUR_SCRIPT=/opt/cfour/cfour; NCPUS=4".into()
     }
 
     fn write_submit_script(

--- a/src/program/cfour.rs
+++ b/src/program/cfour.rs
@@ -224,6 +224,14 @@ impl Program for Cfour {
 impl Submit<Cfour> for Pbs {}
 
 impl Queue<Cfour> for Pbs {
+    fn template(&self) -> &Option<String> {
+        &self.template
+    }
+
+    fn program_cmd(&self, filename: &str) -> String {
+        format!("(cd {filename} && $CFOUR_SCRIPT $NCPUS)")
+    }
+
     fn default_submit_script(&self) -> String {
         "#!/bin/sh
 #PBS -N {{.basename}}
@@ -245,42 +253,18 @@ CFOUR_SCRIPT=/ddn/home8/r2610/bin/c4ext_new.sh
 "
         .to_owned()
     }
-
-    fn write_submit_script(
-        &self,
-        infiles: impl IntoIterator<Item = String>,
-        filename: &str,
-    ) {
-        use std::fmt::Write;
-        let path = Path::new(filename);
-        let basename = path.file_name().unwrap();
-        let mut body = self
-            .template
-            .clone()
-            .unwrap_or_else(|| {
-                <Self as Queue<Cfour>>::default_submit_script(self)
-            })
-            .replace("{{.basename}}", basename.to_str().unwrap())
-            .replace("{{.filename}}", filename);
-        for f in infiles {
-            writeln!(body, "(cd {f} && $CFOUR_SCRIPT $NCPUS)").unwrap();
-        }
-        if std::fs::write(filename, body).is_err() {
-            panic!("write_submit_script: failed to create {filename}");
-        };
-    }
 }
 
 impl Queue<Cfour> for Slurm {
-    fn default_submit_script(&self) -> String {
-        todo!()
+    fn template(&self) -> &Option<String> {
+        &self.template
     }
 
-    fn write_submit_script(
-        &self,
-        _infiles: impl IntoIterator<Item = String>,
-        _filename: &str,
-    ) {
+    fn program_cmd(&self, filename: &str) -> String {
+        format!("(cd {filename} && $CFOUR_SCRIPT $NCPUS)")
+    }
+
+    fn default_submit_script(&self) -> String {
         todo!()
     }
 }
@@ -288,32 +272,16 @@ impl Queue<Cfour> for Slurm {
 impl Submit<Cfour> for Local {}
 
 impl Queue<Cfour> for Local {
-    fn default_submit_script(&self) -> String {
-        "CFOUR_SCRIPT=/opt/cfour/cfour; NCPUS=4".into()
+    fn template(&self) -> &Option<String> {
+        &self.template
     }
 
-    fn write_submit_script(
-        &self,
-        infiles: impl IntoIterator<Item = String>,
-        filename: &str,
-    ) {
-        use std::fmt::Write;
-        let path = Path::new(filename);
-        let basename = path.file_name().unwrap();
-        let mut body = self
-            .template
-            .clone()
-            .unwrap_or_else(|| {
-                <Self as Queue<Cfour>>::default_submit_script(self)
-            })
-            .replace("{{.basename}}", basename.to_str().unwrap())
-            .replace("{{.filename}}", filename);
-        for f in infiles {
-            writeln!(body, "(cd {f} && $CFOUR_SCRIPT $NCPUS)").unwrap();
-        }
-        if std::fs::write(filename, body).is_err() {
-            panic!("write_submit_script: failed to create {filename}");
-        };
+    fn program_cmd(&self, filename: &str) -> String {
+        format!("(cd {filename} && $CFOUR_SCRIPT $NCPUS)")
+    }
+
+    fn default_submit_script(&self) -> String {
+        "CFOUR_SCRIPT=/opt/cfour/cfour; NCPUS=4".into()
     }
 }
 

--- a/src/program/mopac/tests.rs
+++ b/src/program/mopac/tests.rs
@@ -200,18 +200,13 @@ struct TestQueue;
 impl Submit<Mopac> for TestQueue {}
 
 impl Queue<Mopac> for TestQueue {
-    fn write_submit_script(
-        &self,
-        infiles: impl IntoIterator<Item = String>,
-        filename: &str,
-    ) {
-        let mut body = String::new();
-        for f in infiles {
-            body.push_str(&format!("echo {f}\n"));
-        }
-        let mut file =
-            File::create(filename).expect("failed to create params file");
-        write!(file, "{body}").expect("failed to write params file");
+    fn template(&self) -> &Option<String> {
+        static S: Option<String> = Some(String::new());
+        &S
+    }
+
+    fn program_cmd(&self, filename: &str) -> String {
+        format!("echo {filename}")
     }
 
     fn default_submit_script(&self) -> String {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -95,12 +95,7 @@ where
 
 pub trait Queue<P>: SubQueue<P> + Submit<P>
 where
-    P: Program
-        + Clone
-        + Send
-        + std::marker::Sync
-        + Serialize
-        + for<'a> Deserialize<'a>,
+    P: Program + Clone + Send + Sync + Serialize + for<'a> Deserialize<'a>,
 {
     fn default_submit_script(&self) -> String;
 
@@ -244,7 +239,7 @@ where
         dst: &mut [Geom],
     ) -> Result<f64, Vec<usize>>
     where
-        Self: std::marker::Sync,
+        Self: Sync,
     {
         Opt.drain(dir, self, jobs, dst, Check::None)
     }
@@ -278,7 +273,7 @@ where
         check: Check,
     ) -> Result<f64, Vec<usize>>
     where
-        Self: std::marker::Sync,
+        Self: Sync,
     {
         Single.drain(dir, self, jobs, dst, check)
     }
@@ -290,7 +285,7 @@ where
         dst: &mut [ProgramResult],
     ) -> Result<f64, Vec<usize>>
     where
-        Self: std::marker::Sync,
+        Self: Sync,
     {
         Both.drain(dir, self, jobs, dst, Check::None)
     }

--- a/src/queue/local.rs
+++ b/src/queue/local.rs
@@ -60,7 +60,7 @@ impl Queue<Molpro> for Local {
     }
 
     fn default_submit_script(&self) -> String {
-        todo!()
+        String::new()
     }
 }
 
@@ -227,7 +227,7 @@ mod tests {
 
     make_tests! {
         mopac_local, &local() =>  Mopac,
-        // molpro_local, &local() =>  Molpro,
+        molpro_local, &local() =>  Molpro,
         cfour_local, &local() => Cfour,
         dftb_local, &local() => DFTBPlus,
     }

--- a/src/queue/local.rs
+++ b/src/queue/local.rs
@@ -108,30 +108,11 @@ impl Queue<DFTBPlus> for Local {
     }
 
     fn program_cmd(&self, filename: &str) -> String {
-        format!("cd {filename} && $DFTB_PATH > out")
+        format!("(cd {filename} && $DFTB_PATH > out)")
     }
 
     fn default_submit_script(&self) -> String {
-        todo!()
-    }
-
-    fn write_submit_script(
-        &self,
-        infiles: impl IntoIterator<Item = String>,
-        filename: &str,
-    ) {
-        use std::fmt::Write;
-        let mut body = String::new();
-        // assume f is a directory name, not a real file
-        let c = std::env::var("DFTB_PATH").unwrap_or("/opt/dftb+/dftb+".into());
-        for f in infiles {
-            writeln!(body, "(cd {f} && {c} > out)").unwrap();
-        }
-        writeln!(body, "date +%s >> {filename}.out").unwrap();
-        let mut file = File::create(filename).unwrap_or_else(|_| {
-            panic!("failed to create submit script `{filename}`")
-        });
-        write!(file, "{body}").expect("failed to write submit script");
+        "DFTB_PATH=/opt/dftb+/dftb+\n".into()
     }
 }
 

--- a/src/queue/local.rs
+++ b/src/queue/local.rs
@@ -51,15 +51,15 @@ impl Local {
 impl Submit<Molpro> for Local {}
 
 impl Queue<Molpro> for Local {
-    fn default_submit_script(&self) -> String {
-        todo!()
+    fn template(&self) -> &Option<String> {
+        &self.template
     }
 
-    fn write_submit_script(
-        &self,
-        _infiles: impl IntoIterator<Item = String>,
-        _filename: &str,
-    ) {
+    fn program_cmd(&self, filename: &str) -> String {
+        format!("{} {filename}.mop &> {filename}.out", self.mopac)
+    }
+
+    fn default_submit_script(&self) -> String {
         todo!()
     }
 }
@@ -67,6 +67,14 @@ impl Queue<Molpro> for Local {
 impl Submit<Mopac> for Local {}
 
 impl Queue<Mopac> for Local {
+    fn template(&self) -> &Option<String> {
+        &self.template
+    }
+
+    fn program_cmd(&self, filename: &str) -> String {
+        format!("{} {filename}.mop", self.mopac)
+    }
+
     fn write_submit_script(
         &self,
         infiles: impl IntoIterator<Item = String>,
@@ -88,13 +96,21 @@ impl Queue<Mopac> for Local {
     }
 
     fn default_submit_script(&self) -> String {
-        todo!()
+        "export LD_LIBRARY_PATH=/opt/mopac/\n".into()
     }
 }
 
 impl Submit<DFTBPlus> for Local {}
 
 impl Queue<DFTBPlus> for Local {
+    fn template(&self) -> &Option<String> {
+        &self.template
+    }
+
+    fn program_cmd(&self, filename: &str) -> String {
+        format!("cd {filename} && $DFTB_PATH > out")
+    }
+
     fn default_submit_script(&self) -> String {
         todo!()
     }

--- a/src/queue/pbs.rs
+++ b/src/queue/pbs.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-use std::io::Write;
 use std::path::Path;
 use std::time::Duration;
 use std::{collections::HashSet, process::Command};
@@ -210,32 +208,6 @@ cd $WORKDIR
 export DFTB_PATH=/ddnlus/r2518/.conda/envs/dftb/bin/dftb+
 "
         .to_owned()
-    }
-
-    fn write_submit_script(
-        &self,
-        infiles: impl IntoIterator<Item = String>,
-        filename: &str,
-    ) {
-        use std::fmt::Write;
-        let path = Path::new(filename);
-        let basename = path.file_name().unwrap();
-        let mut body = self
-            .template
-            .clone()
-            .unwrap_or_else(|| {
-                <Self as Queue<DFTBPlus>>::default_submit_script(self)
-            })
-            .replace("{{.basename}}", basename.to_str().unwrap())
-            .replace("{{.filename}}", filename);
-        for f in infiles {
-            writeln!(body, "(cd {f} && $DFTB_PATH > out)").unwrap();
-        }
-        let Ok(mut file) = File::create(filename) else {
-            eprintln!("write_submit_script: failed to create {filename}");
-            std::process::exit(1);
-        };
-        write!(file, "{body}").expect("failed to write DFTB+ PBS file");
     }
 }
 

--- a/src/queue/pbs.rs
+++ b/src/queue/pbs.rs
@@ -155,37 +155,7 @@ impl Queue<Mopac> for Pbs {
     }
 
     fn program_cmd(&self, filename: &str) -> String {
-        format!("$MOPAC_PATH {filename}.mop\n")
-    }
-
-    /// An example of `self.template` should look like
-    ///
-    fn write_submit_script(
-        &self,
-        infiles: impl IntoIterator<Item = String>,
-        filename: &str,
-    ) {
-        let path = Path::new(filename);
-        let basename = path.file_name().unwrap();
-        let mut body = self
-            .template
-            .clone()
-            .unwrap_or_else(|| {
-                <Self as Queue<Mopac>>::default_submit_script(self)
-            })
-            .replace("{{.basename}}", basename.to_str().unwrap())
-            .replace("{{.filename}}", filename);
-        for f in infiles {
-            body.push_str(&format!("$MOPAC_PATH {f}.mop\n"));
-        }
-        let mut file = match File::create(filename) {
-            Ok(f) => f,
-            Err(_) => {
-                eprintln!("write_submit_script: failed to create {filename}");
-                std::process::exit(1);
-            }
-        };
-        write!(file, "{body}").expect("failed to write params file");
+        format!("$MOPAC_PATH {filename}.mop")
     }
 
     fn default_submit_script(&self) -> String {

--- a/src/queue/slurm.rs
+++ b/src/queue/slurm.rs
@@ -1,6 +1,4 @@
 use std::collections::HashSet;
-use std::fs::File;
-use std::io::Write;
 
 use serde::{Deserialize, Serialize};
 
@@ -78,34 +76,7 @@ impl Queue<Mopac> for Slurm {
     }
 
     fn program_cmd(&self, filename: &str) -> String {
-        format!("/home/qc/mopac2016/MOPAC2016.exe {filename}.mop\n")
-    }
-
-    fn write_submit_script(
-        &self,
-        infiles: impl IntoIterator<Item = String>,
-        filename: &str,
-    ) {
-        let mut body = self
-            .template
-            .clone()
-            .unwrap_or_else(|| {
-                <Self as Queue<Mopac>>::default_submit_script(self)
-            })
-            .replace("{{.filename}}", filename);
-        for f in infiles {
-            body.push_str(&format!(
-                "/home/qc/mopac2016/MOPAC2016.exe {f}.mop\n"
-            ));
-        }
-        let mut file = match File::create(filename) {
-            Ok(f) => f,
-            Err(_) => {
-                eprintln!("write_submit_script: failed to create {filename}");
-                std::process::exit(1);
-            }
-        };
-        write!(file, "{body}").expect("failed to write params file");
+        format!("/home/qc/mopac2016/MOPAC2016.exe {filename}.mop")
     }
 
     fn default_submit_script(&self) -> String {

--- a/src/queue/slurm.rs
+++ b/src/queue/slurm.rs
@@ -57,33 +57,6 @@ impl Queue<Molpro> for Slurm {
         format!("$MOLPRO_CMD {filename}.inp")
     }
 
-    fn write_submit_script(
-        &self,
-        infiles: impl IntoIterator<Item = String>,
-        filename: &str,
-    ) {
-        let mut body = self
-            .template
-            .clone()
-            .unwrap_or_else(|| {
-                <Self as Queue<Molpro>>::default_submit_script(self)
-            })
-            .replace("{{.filename}}", filename);
-        for f in infiles {
-            body.push_str(&format!("$MOLPRO_CMD {f}.inp\n"));
-        }
-        let mut file = match File::create(filename) {
-            Ok(f) => f,
-            Err(_) => {
-                eprintln!("write_submit_script: failed to create {filename}");
-                std::process::exit(1);
-            }
-        };
-        write!(file, "{body}").unwrap_or_else(|_| {
-            panic!("failed to write molpro input file: {filename}")
-        });
-    }
-
     fn default_submit_script(&self) -> String {
         "#!/bin/bash
 #SBATCH --job-name={{.filename}}
@@ -161,15 +134,7 @@ impl Queue<DFTBPlus> for Slurm {
     }
 
     fn default_submit_script(&self) -> String {
-        todo!()
-    }
-
-    fn write_submit_script(
-        &self,
-        _infiles: impl IntoIterator<Item = String>,
-        _filename: &str,
-    ) {
-        todo!()
+        String::new()
     }
 }
 
@@ -243,6 +208,8 @@ where
 mod tests {
     use insta::assert_snapshot;
 
+    use crate::program::cfour::Cfour;
+
     use super::*;
 
     fn slurm() -> Slurm {
@@ -281,7 +248,7 @@ mod tests {
     make_tests! {
         mopac_slurm, &slurm() =>  Mopac,
         molpro_slurm, &slurm() => Molpro,
-        // cfour_slurm, &slurm() => Slurm, Cfour,
-        // dftb_slurm, &slurm() => Slurm, DFTBPlus,
+        cfour_slurm, &slurm() => Cfour,
+        dftb_slurm, &slurm() => DFTBPlus,
     }
 }

--- a/src/queue/slurm.rs
+++ b/src/queue/slurm.rs
@@ -20,7 +20,7 @@ pub struct Slurm {
     sleep_int: usize,
     dir: &'static str,
     no_del: bool,
-    template: Option<String>,
+    pub(crate) template: Option<String>,
 }
 
 impl Slurm {
@@ -49,6 +49,14 @@ impl<P: Program + Clone + Serialize + for<'a> Deserialize<'a>> Submit<P>
 }
 
 impl Queue<Molpro> for Slurm {
+    fn template(&self) -> &Option<String> {
+        &self.template
+    }
+
+    fn program_cmd(&self, filename: &str) -> String {
+        format!("$MOLPRO_CMD {filename}.inp")
+    }
+
     fn write_submit_script(
         &self,
         infiles: impl IntoIterator<Item = String>,
@@ -92,6 +100,14 @@ MOLPRO_CMD=\"/home/qc/bin/molpro2020.sh 1 1\"
 }
 
 impl Queue<Mopac> for Slurm {
+    fn template(&self) -> &Option<String> {
+        &self.template
+    }
+
+    fn program_cmd(&self, filename: &str) -> String {
+        format!("/home/qc/mopac2016/MOPAC2016.exe {filename}.mop\n")
+    }
+
     fn write_submit_script(
         &self,
         infiles: impl IntoIterator<Item = String>,
@@ -136,6 +152,14 @@ hostname\n"
 }
 
 impl Queue<DFTBPlus> for Slurm {
+    fn template(&self) -> &Option<String> {
+        &self.template
+    }
+
+    fn program_cmd(&self, filename: &str) -> String {
+        format!("(cd {filename} && $DFTB_PATH > out)")
+    }
+
     fn default_submit_script(&self) -> String {
         todo!()
     }

--- a/src/queue/slurm.rs
+++ b/src/queue/slurm.rs
@@ -214,3 +214,33 @@ where
         self.no_del
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    fn slurm() -> Slurm {
+        Slurm {
+            chunk_size: 1,
+            job_limit: 1,
+            sleep_int: 1,
+            dir: "/tmp",
+            no_del: false,
+            template: None,
+        }
+    }
+
+    #[test]
+    fn molpro_slurm() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        <Slurm as Queue<Molpro>>::write_submit_script(
+            &slurm(),
+            ["opt0.inp", "opt1.inp", "opt2.inp", "opt3.inp"].map(|s| s.into()),
+            tmp.path().to_str().unwrap(),
+        );
+        let got = std::fs::read_to_string(tmp).unwrap();
+        assert_snapshot!(got);
+    }
+}

--- a/src/queue/slurm.rs
+++ b/src/queue/slurm.rs
@@ -233,12 +233,12 @@ mod tests {
     }
 
     macro_rules! make_tests {
-        ($($name:ident, $queue:expr => $q:ty, $p:ty$(,)*)*) => {
+        ($($name:ident, $queue:expr => $p:ty$(,)*)*) => {
             $(
             #[test]
             fn $name() {
                 let tmp = tempfile::NamedTempFile::new().unwrap();
-                <$q as Queue<$p>>::write_submit_script(
+                <Slurm as Queue<$p>>::write_submit_script(
                     $queue,
                     ["opt0.inp", "opt1.inp", "opt2.inp", "opt3.inp"].map(|s| s.into()),
                     tmp.path().to_str().unwrap(),
@@ -255,8 +255,8 @@ mod tests {
     }
 
     make_tests! {
-        mopac_slurm, &slurm() => Slurm, Mopac,
-        molpro_slurm, &slurm() => Slurm, Molpro,
+        mopac_slurm, &slurm() =>  Mopac,
+        molpro_slurm, &slurm() => Molpro,
         // cfour_slurm, &slurm() => Slurm, Cfour,
         // dftb_slurm, &slurm() => Slurm, DFTBPlus,
     }

--- a/src/queue/slurm.rs
+++ b/src/queue/slurm.rs
@@ -255,18 +255,9 @@ mod tests {
     }
 
     make_tests! {
+        mopac_slurm, &slurm() => Slurm, Mopac,
         molpro_slurm, &slurm() => Slurm, Molpro,
+        // cfour_slurm, &slurm() => Slurm, Cfour,
+        // dftb_slurm, &slurm() => Slurm, DFTBPlus,
     }
-
-    // #[test]
-    // fn mopac_slurm() {
-    //     let tmp = tempfile::NamedTempFile::new().unwrap();
-    //     <Slurm as Queue<Mopac>>::write_submit_script(
-    //         &slurm(),
-    //         ["opt0.inp", "opt1.inp", "opt2.inp", "opt3.inp"].map(|s| s.into()),
-    //         tmp.path().to_str().unwrap(),
-    //     );
-    //     let got = std::fs::read_to_string(tmp).unwrap();
-    //     assert_snapshot!(got);
-    // }
 }

--- a/src/queue/snapshots/psqs__queue__local__tests__cfour_local.snap
+++ b/src/queue/snapshots/psqs__queue__local__tests__cfour_local.snap
@@ -1,0 +1,8 @@
+---
+source: src/queue/local.rs
+expression: got
+---
+CFOUR_SCRIPT=/opt/cfour/cfour; NCPUS=4(cd opt0.inp && $CFOUR_SCRIPT $NCPUS)
+(cd opt1.inp && $CFOUR_SCRIPT $NCPUS)
+(cd opt2.inp && $CFOUR_SCRIPT $NCPUS)
+(cd opt3.inp && $CFOUR_SCRIPT $NCPUS)

--- a/src/queue/snapshots/psqs__queue__local__tests__dftb_local.snap
+++ b/src/queue/snapshots/psqs__queue__local__tests__dftb_local.snap
@@ -1,0 +1,8 @@
+---
+source: src/queue/local.rs
+expression: got
+---
+(cd opt0.inp && /opt/dftb+/dftb+ > out)
+(cd opt1.inp && /opt/dftb+/dftb+ > out)
+(cd opt2.inp && /opt/dftb+/dftb+ > out)
+(cd opt3.inp && /opt/dftb+/dftb+ > out)

--- a/src/queue/snapshots/psqs__queue__local__tests__dftb_local.snap
+++ b/src/queue/snapshots/psqs__queue__local__tests__dftb_local.snap
@@ -2,7 +2,8 @@
 source: src/queue/local.rs
 expression: got
 ---
-(cd opt0.inp && /opt/dftb+/dftb+ > out)
-(cd opt1.inp && /opt/dftb+/dftb+ > out)
-(cd opt2.inp && /opt/dftb+/dftb+ > out)
-(cd opt3.inp && /opt/dftb+/dftb+ > out)
+DFTB_PATH=/opt/dftb+/dftb+
+(cd opt0.inp && $DFTB_PATH > out)
+(cd opt1.inp && $DFTB_PATH > out)
+(cd opt2.inp && $DFTB_PATH > out)
+(cd opt3.inp && $DFTB_PATH > out)

--- a/src/queue/snapshots/psqs__queue__local__tests__molpro_local.snap
+++ b/src/queue/snapshots/psqs__queue__local__tests__molpro_local.snap
@@ -1,0 +1,8 @@
+---
+source: src/queue/local.rs
+expression: got
+---
+mopac opt0.inp.mop &> opt0.inp.out
+mopac opt1.inp.mop &> opt1.inp.out
+mopac opt2.inp.mop &> opt2.inp.out
+mopac opt3.inp.mop &> opt3.inp.out

--- a/src/queue/snapshots/psqs__queue__local__tests__mopac_local.snap
+++ b/src/queue/snapshots/psqs__queue__local__tests__mopac_local.snap
@@ -1,0 +1,5 @@
+---
+source: src/queue/local.rs
+expression: got
+---
+export LD_LIBRARY_PATH=/opt/mopac/

--- a/src/queue/snapshots/psqs__queue__pbs__tests__cfour_pbs.snap
+++ b/src/queue/snapshots/psqs__queue__pbs__tests__cfour_pbs.snap
@@ -1,0 +1,23 @@
+---
+source: src/queue/pbs.rs
+expression: got
+---
+#!/bin/sh
+#PBS -S /bin/bash
+#PBS -j oe
+#PBS -W umask=022
+#PBS -l walltime=1000:00:00
+#PBS -l ncpus=1
+#PBS -l mem=8gb
+#PBS -q workq
+
+module load openpbs
+
+export WORKDIR=$PBS_O_WORKDIR
+cd $WORKDIR
+
+CFOUR_SCRIPT=/ddn/home8/r2610/bin/c4ext_new.sh
+(cd opt0.inp && $CFOUR_SCRIPT $NCPUS)
+(cd opt1.inp && $CFOUR_SCRIPT $NCPUS)
+(cd opt2.inp && $CFOUR_SCRIPT $NCPUS)
+(cd opt3.inp && $CFOUR_SCRIPT $NCPUS)

--- a/src/queue/snapshots/psqs__queue__pbs__tests__dftb_pbs.snap
+++ b/src/queue/snapshots/psqs__queue__pbs__tests__dftb_pbs.snap
@@ -1,0 +1,23 @@
+---
+source: src/queue/pbs.rs
+expression: got
+---
+#!/bin/sh
+#PBS -S /bin/bash
+#PBS -j oe
+#PBS -W umask=022
+#PBS -l walltime=1000:00:00
+#PBS -l ncpus=1
+#PBS -l mem=8gb
+#PBS -q workq
+
+module load openpbs
+
+export WORKDIR=$PBS_O_WORKDIR
+cd $WORKDIR
+
+export DFTB_PATH=/ddnlus/r2518/.conda/envs/dftb/bin/dftb+
+(cd opt0.inp && $DFTB_PATH > out)
+(cd opt1.inp && $DFTB_PATH > out)
+(cd opt2.inp && $DFTB_PATH > out)
+(cd opt3.inp && $DFTB_PATH > out)

--- a/src/queue/snapshots/psqs__queue__pbs__tests__molpro_pbs.snap
+++ b/src/queue/snapshots/psqs__queue__pbs__tests__molpro_pbs.snap
@@ -1,0 +1,24 @@
+---
+source: src/queue/pbs.rs
+expression: got
+---
+#!/bin/sh
+#PBS -S /bin/bash
+#PBS -j oe
+#PBS -W umask=022
+#PBS -l walltime=1000:00:00
+#PBS -l ncpus=1
+#PBS -l mem=8gb
+#PBS -q workq
+
+module load openpbs molpro
+
+export WORKDIR=$PBS_O_WORKDIR
+export TMPDIR=/tmp/$USER/$PBS_JOBID
+cd $WORKDIR
+mkdir -p $TMPDIR
+molpro -t $NCPUS --no-xml-output "opt0.inp".inp
+molpro -t $NCPUS --no-xml-output "opt1.inp".inp
+molpro -t $NCPUS --no-xml-output "opt2.inp".inp
+molpro -t $NCPUS --no-xml-output "opt3.inp".inp
+rm -rf $TMPDIR

--- a/src/queue/snapshots/psqs__queue__pbs__tests__molpro_pbs.snap
+++ b/src/queue/snapshots/psqs__queue__pbs__tests__molpro_pbs.snap
@@ -17,8 +17,8 @@ export WORKDIR=$PBS_O_WORKDIR
 export TMPDIR=/tmp/$USER/$PBS_JOBID
 cd $WORKDIR
 mkdir -p $TMPDIR
-molpro -t $NCPUS --no-xml-output "opt0.inp".inp
-molpro -t $NCPUS --no-xml-output "opt1.inp".inp
-molpro -t $NCPUS --no-xml-output "opt2.inp".inp
-molpro -t $NCPUS --no-xml-output "opt3.inp".inp
-rm -rf $TMPDIR
+trap 'rm -rf $TMPDIR' EXIT
+molpro -t $NCPUS --no-xml-output opt0.inp.inp
+molpro -t $NCPUS --no-xml-output opt1.inp.inp
+molpro -t $NCPUS --no-xml-output opt2.inp.inp
+molpro -t $NCPUS --no-xml-output opt3.inp.inp

--- a/src/queue/snapshots/psqs__queue__pbs__tests__mopac_pbs.snap
+++ b/src/queue/snapshots/psqs__queue__pbs__tests__mopac_pbs.snap
@@ -1,0 +1,23 @@
+---
+source: src/queue/pbs.rs
+expression: got
+---
+#!/bin/sh
+#PBS -S /bin/bash
+#PBS -j oe
+#PBS -W umask=022
+#PBS -l walltime=1000:00:00
+#PBS -l ncpus=1
+#PBS -l mem=1gb
+#PBS -q workq
+
+module load openpbs
+
+export WORKDIR=$PBS_O_WORKDIR
+cd $WORKDIR
+
+export MOPAC_PATH=/ddnlus/r2518/Packages/mopac/build/mopac
+$MOPAC_PATH opt0.inp.mop
+$MOPAC_PATH opt1.inp.mop
+$MOPAC_PATH opt2.inp.mop
+$MOPAC_PATH opt3.inp.mop

--- a/src/queue/snapshots/psqs__queue__slurm__tests__cfour_slurm.snap
+++ b/src/queue/snapshots/psqs__queue__slurm__tests__cfour_slurm.snap
@@ -1,0 +1,8 @@
+---
+source: src/queue/slurm.rs
+expression: got
+---
+(cd opt0.inp && $CFOUR_SCRIPT $NCPUS)
+(cd opt1.inp && $CFOUR_SCRIPT $NCPUS)
+(cd opt2.inp && $CFOUR_SCRIPT $NCPUS)
+(cd opt3.inp && $CFOUR_SCRIPT $NCPUS)

--- a/src/queue/snapshots/psqs__queue__slurm__tests__dftb_slurm.snap
+++ b/src/queue/snapshots/psqs__queue__slurm__tests__dftb_slurm.snap
@@ -1,0 +1,8 @@
+---
+source: src/queue/slurm.rs
+expression: got
+---
+(cd opt0.inp && $DFTB_PATH > out)
+(cd opt1.inp && $DFTB_PATH > out)
+(cd opt2.inp && $DFTB_PATH > out)
+(cd opt3.inp && $DFTB_PATH > out)

--- a/src/queue/snapshots/psqs__queue__slurm__tests__molpro_slurm.snap
+++ b/src/queue/snapshots/psqs__queue__slurm__tests__molpro_slurm.snap
@@ -3,10 +3,8 @@ source: src/queue/slurm.rs
 expression: got
 ---
 #!/bin/bash
-#SBATCH --job-name=/tmp/.tmpe3JtTD
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
-#SBATCH -o /tmp/.tmpe3JtTD.out
 #SBATCH --no-requeue
 #SBATCH --mem=8gb
 

--- a/src/queue/snapshots/psqs__queue__slurm__tests__molpro_slurm.snap
+++ b/src/queue/snapshots/psqs__queue__slurm__tests__molpro_slurm.snap
@@ -1,0 +1,17 @@
+---
+source: src/queue/slurm.rs
+expression: got
+---
+#!/bin/bash
+#SBATCH --job-name=/tmp/.tmpe3JtTD
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH -o /tmp/.tmpe3JtTD.out
+#SBATCH --no-requeue
+#SBATCH --mem=8gb
+
+MOLPRO_CMD="/home/qc/bin/molpro2020.sh 1 1"
+$MOLPRO_CMD opt0.inp.inp
+$MOLPRO_CMD opt1.inp.inp
+$MOLPRO_CMD opt2.inp.inp
+$MOLPRO_CMD opt3.inp.inp

--- a/src/queue/snapshots/psqs__queue__slurm__tests__mopac_slurm.snap
+++ b/src/queue/snapshots/psqs__queue__slurm__tests__mopac_slurm.snap
@@ -1,0 +1,17 @@
+---
+source: src/queue/slurm.rs
+expression: got
+---
+#!/bin/bash
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --no-requeue
+#SBATCH --mem=1gb
+export LD_LIBRARY_PATH=/home/qc/mopac2016/
+echo $SLURM_JOB_ID
+date
+hostname
+/home/qc/mopac2016/MOPAC2016.exe opt0.inp.mop
+/home/qc/mopac2016/MOPAC2016.exe opt1.inp.mop
+/home/qc/mopac2016/MOPAC2016.exe opt2.inp.mop
+/home/qc/mopac2016/MOPAC2016.exe opt3.inp.mop


### PR DESCRIPTION
As I start adding stuff like `MOLPRO_CMD` and `MOPAC_CMD` and such, the `write_submit_script` implementations start getting more and more similar. This PR factors out basically all of the commonality and allows writing a single* `Queue::write_submit_script` that calls out to the new `Queue::template` and `Queue::program_cmd` methods, which are essentially trivial to implement.

One other important observation I made while doing this was that there was "no way" to clean up `TMPDIR` for example when using a custom `queue_template` in pbqff because the job filename lines are placed at the end of the file. The default Molpro script now uses a `trap` on exit to clean this up. Custom queue templates should do the same.

* The one place with a unique `write_submit_script` is for MOPAC on a Local queue because it writes a lot of extra debugging information for use in testing.